### PR TITLE
Esempio fuori contesto

### DIFF
--- a/doc/service-design/accessibilita.rst
+++ b/doc/service-design/accessibilita.rst
@@ -120,7 +120,7 @@ Comportamento
    `WAI ARIA <https://www.w3.org/WAI/intro/aria>`__).
 
 Un esempio per capire: uso del colore
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Il colore non può essere usato come unico mezzo per veicolare
 un’informazione. Quindi, ad esempio, non possono essere indicate in

--- a/doc/service-design/accessibilita.rst
+++ b/doc/service-design/accessibilita.rst
@@ -119,7 +119,7 @@ Comportamento
    all’utente, in particolare alle tecnologie assistive (vedi 
    `WAI ARIA <https://www.w3.org/WAI/intro/aria>`__).
 
-Uso dei colori per veicolare informazioni
+Un esempio per capire: uso del colore
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Il colore non può essere usato come unico mezzo per veicolare
@@ -133,8 +133,7 @@ colore in contesti di fruizione diversi e molto frequenti, ad es.:
 -  in caso di daltonismo (8% popolazione maschile)
 
 Per comunicare un’informazione, oltre al colore è necessario aggiungere
-un elemento testuale o grafico, un simbolo o un bordo, per fare alcuni
-esempi.
+un elemento testuale o grafico, un simbolo o un bordo.
 
 Normativa
 ~~~~~~~~~


### PR DESCRIPTION
Il documento orginale è pensato per non esperti e dopo una breve
introduzione contiene questo esempio.
L’esempio posto in fondo, dopo spiegazioni molto più tecniche, perde di senso. 

Per ridare il senso perduto ma non modificare la struttura del documento, suggerisco almeno di cambiare il titolo,